### PR TITLE
Return exit code 1 on error instead of lying

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -3,4 +3,4 @@
 
 "use strict";
 
-require("../lib/cli.js")(process.argv, require("../lib/build.js"), process.stderr);
+require("../lib/cli.js")(process.argv, require("../lib/build.js"), process.stderr, process);

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -28,12 +28,16 @@ _logLevel = function(argv) {
     return argv.loglevel;
 };
 
-module.exports = function cli(argv, Build, stream) {
+module.exports = function cli(argv, Build, stream, process) {
     var config  = {},
         args    = optimist
                     .parse(argv.slice(2)),
                     
         build, configs;
+    
+    if(!process) {
+        process = global.process;
+    }
     
     if(args.help) {
         return optimist.showHelp(stream.write);
@@ -128,6 +132,10 @@ module.exports = function cli(argv, Build, stream) {
     build.run(args._.length ? args._ : null, function(error) {
         if(error) {
             log.error("cli", "Build failed due to \"" + error + "\"");
+            
+            process.on("exit", function() {
+                process.exit(1);
+            });
         }
     });
 };

--- a/test/cli.js
+++ b/test/cli.js
@@ -12,7 +12,7 @@ var assert = require("assert"),
     _root = process.cwd(),
     _argv = [,,],
     
-    _build, _stream;
+    _build, _stream, _process;
 
 _build = function(fn, proto) {
     var B;
@@ -44,6 +44,16 @@ _stream = function(write) {
     s.write = write || function() {};
     
     return s;
+};
+
+_process = function(exit) {
+    return {
+        cwd : process.cwd,
+        on  : function(ev, fn) {
+            fn();
+        },
+        exit : exit || function() {}
+    };
 };
 
 describe("Dullard", function() {
@@ -93,7 +103,10 @@ describe("Dullard", function() {
                     function(msg) {
                         result += msg;
                     }
-                )
+                ),
+                _process(function(code) {
+                    assert.equal(code, 1);
+                })
             );
             
             assert(result.indexOf("No tasks available") > -1);
@@ -107,7 +120,8 @@ describe("Dullard", function() {
                     function(msg) {
                         assert(false, "Should not have been called");
                     }
-                )
+                ),
+                _process()
             );
         });
         
@@ -121,7 +135,8 @@ describe("Dullard", function() {
                 Build,
                 _stream(function(msg) {
                     result += msg;
-                })
+                }),
+                _process()
             );
             
             assert(/^verb/.test(result));
@@ -270,6 +285,9 @@ describe("Dullard", function() {
                 Build,
                 _stream(function(msg) {
                     result += msg;
+                }),
+                _process(function(code) {
+                    assert.equal(code, 1);
                 })
             );
             


### PR DESCRIPTION
Always returning `0` is a real bad idea.
