### PR TITLE
Delay task loading until it's necessary

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -51,8 +51,9 @@ _.extend(Build.prototype, {
             var full  = path.join(dir, file),
                 name  = path.basename(file, path.extname(file));
 
-            self.tasks[name]        = require(full);
-            self.tasks[name].source = full;
+            self.tasks[name] = {
+                source : full
+            };
         });
     },
 
@@ -124,14 +125,31 @@ _.extend(Build.prototype, {
                     return self._runSteps(step, cb);
                 }
 
-                var type      = typeof step,
-                    task      = (type === "function") ? step : self.tasks[step],
-                    name      = (type === "function") ? step.name : step,
-                    startTask = Date.now(),
-                    result;
+                var startTask = Date.now(),
+                    task,
+                    name,
+                    result,
+                    source;
 
-                if(!task) {
-                    return cb("Unknown task: " + name);
+                // if we were passed a function, just go ahead and run it
+                if(typeof step === "function") {
+                    task = step;
+                    name = step.name;
+                // otherwise, it's probably a string
+                } else {
+                    name = step;
+                    // if we've already loaded the step, just use it
+                    if(typeof self.tasks[step] === "function") {
+                        task = self.tasks[step];
+                    // otherwise, go load the step and update its entry
+                    } else if(self.tasks[step]) {
+                        source = self.tasks[step].source;
+                        task   = require(source);
+                        self.tasks[step] = task;
+                        self.tasks[step].source = source;
+                    } else {
+                        return cb("Unknown task: " + name);
+                    }
                 }
 
                 self._current = name;

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -107,7 +107,18 @@ module.exports = function cli(argv, Build, stream, process) {
         Object.keys(build.tasks)
             .sort()
             .forEach(function(name) {
-                var task = build.tasks[name];
+                var task   = build.tasks[name],
+                    source = task.source;
+
+                // the task probably hasn't been loaded, so load it up
+                if(typeof task !== "function") {
+                    try {
+                        task = require(source);
+                        task.source = source;
+                    } catch(e) {
+                        // just ignore the error, since it doesn't really matter
+                    }
+                }
 
                 stream.write("\"" + name + "\"\n");
                 stream.write("    source: " + task.source + "\n");


### PR DESCRIPTION
This change fixes #25 by delaying task loading until the task is actually run, or the CLI is asked to list the available tasks. Tasks are still located as part of dullard's startup process, but aren't actually required until they're run.

When the tasks are loaded so the CLI can list them, we ignore any errors that may be caused by side effects from loading a module, since we're not really interested at that point.

All of the tests pass, and dullard seems to be running fine for me after this change.
