### PR TITLE
Show correct log prefix for step summary message

### DIFF
--- a/lib/dullard.js
+++ b/lib/dullard.js
@@ -147,11 +147,15 @@ _.extend(Build.prototype, {
         }
     },
 
-    _runSteps : function(steps, done) {
-        if(this.steps && (steps in this.steps)) {
-            steps = this.steps[steps];
-        } else if(steps in this.tasks) {
-            steps = [ steps ];
+    _runSteps : function(name, done) {
+        var steps;
+
+        if(this.steps && (name in this.steps)) {
+            steps = this.steps[name];
+        } else if(name in this.tasks) {
+            steps = [ name ];
+        } else {
+            steps = name;
         }
 
         if(!steps) {
@@ -162,6 +166,9 @@ _.extend(Build.prototype, {
             steps = [ steps ];
         }
 
+        // Set up current even though we're not into .runTask yet
+        // so that the log will have the right prefix
+        this._current = name;
         this._log("verbose", "Running steps:\n\t%s", steps.join("\n\t"));
 
         async.eachSeries(


### PR DESCRIPTION
Turns output from 

```
verb dullard Running steps:
verb dullard    wordpress-setup
verb dullard    setup
verb dullard    php-tags-transform
verb dullard    core
verb dullard    php-tags-revert
verb dullard    finish
verb dullard Running steps:
verb dullard    portal-dirs
verb dullard    wordpress-cwd
verb portal-dirs started
info portal-dirs complete in 3 milliseconds
```

into

```
verb default Running steps:
verb default    wordpress-setup
verb default    setup
verb default    php-tags-transform
verb default    core
verb default    php-tags-revert
verb default    finish
verb wordpress-setup Running steps:
verb wordpress-setup    portal-dirs
verb wordpress-setup    wordpress-cwd
verb portal-dirs started
info portal-dirs complete in 3 milliseconds
```

which is much more useful.
