### PR TITLE
Silly argument (-s|--silly)

### DIFF
--- a/args.json
+++ b/args.json
@@ -30,6 +30,12 @@
         "description" : "Verbose logging",
         "boolean"     : true
     },
+    
+    "silly" : {
+        "alias"       : "s",
+        "description" : "Silly logging",
+        "boolean"     : true
+    },
 
     "loglevel"  : {
         "description" : "Chattiness, one of: silly, verbose, info, warn, error, & silent",

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -34,6 +34,10 @@ Cli.prototype = {
         if(this.args.verbose) {
             return "verbose";
         }
+        
+        if(this.args.silly) {
+            return "silly";
+        }
 
         return this.args.loglevel;
     },

--- a/test/cli.js
+++ b/test/cli.js
@@ -122,6 +122,28 @@ describe("Dullard", function() {
             
             assert(/^verb/.test(result));
         });
+        
+        it("should be annoying in silly mode", function() {
+            var result = "",
+                cli;
+            
+            process.chdir("./test/specimens/config-json");
+            
+            cli = new Cli({
+                argv    : [].concat(_argv, "--silly"),
+                Dullard : Dullard,
+                process : _process(),
+                stream  : _stream(function(msg) {
+                    result += msg;
+                })
+            });
+            
+            cli.run();
+            
+            console.log(result);
+            
+            assert(/^sill/m.test(result));
+        });
               
         it("should find a local .dullfile containing JS", function() {
             var configs = [],

--- a/test/specimens/tasks-b/b.js
+++ b/test/specimens/tasks-b/b.js
@@ -2,4 +2,6 @@
 
 "use strict";
 
-module.exports = function() {};
+module.exports = function(config) {
+    config.log("silly", "hi");
+};


### PR DESCRIPTION
More easily enable silly output. `-s|--silly` > `--loglevel=silly`

I am the only one who cares.