### PR TITLE
fix: Correct merge order precedence

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,4 +1,2 @@
-test/specimens/
-test/results/
-test/output/
+test/
 coverage/

--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,8 @@ $RECYCLE.BIN/
 .DS_Store
 
 # Folders
-node_modules
-temp
-coverage
-output
+node_modules/
+temp/
+coverage/
+output/
+.vscode/

--- a/src/cli.js
+++ b/src/cli.js
@@ -88,11 +88,11 @@ Cli.prototype = {
                     // just ignore the error, since it doesn't really matter
                 }
 
-                self.stream.write("\"" + name + "\"\n");
-                self.stream.write("    source: " + task.source + "\n");
+                self.stream.write(`"${name}"\n`);
+                self.stream.write(`    source: ${task.source}\n`);
 
                 if(task.description) {
-                    self.stream.write("    desc  : " + task.description + "\n");
+                    self.stream.write(`    desc  : ${task.description}\n`);
                 }
 
                 self.stream.write("\n");

--- a/src/dullard.js
+++ b/src/dullard.js
@@ -127,7 +127,7 @@ assign(Build.prototype, {
         task = this._loadTask(name);
 
         if(!task) {
-            return done("Unknown task: " + name);
+            return done(`Unknown task: ${name}`);
         }
 
         this._current = name.toString();
@@ -150,7 +150,7 @@ assign(Build.prototype, {
                     self._config = config;
                 }
 
-                self._log("complete in " + time(Date.now() - start));
+                self._log(`complete in ${time(Date.now() - start)}`);
 
                 return done();
             });
@@ -221,7 +221,7 @@ assign(Build.prototype, {
         this._log("verbose", "Build starting");
 
         this._runSteps(steps, function(error) {
-            this._log("build complete in " + time(Date.now() - start));
+            this._log(`build complete in ${time(Date.now() - start)}`);
 
             return (typeof done === "function") ? done(error) : true;
         }.bind(this));
@@ -234,6 +234,7 @@ assign(Build.prototype, {
     },
     
     addConfig : function(config) {
+        /* eslint max-statements:["error", 18] */
         var self = this,
             file, cwd;
         

--- a/src/dullard.js
+++ b/src/dullard.js
@@ -265,23 +265,10 @@ assign(Build.prototype, {
         } else {
             config.steps = {};
         }
-        
-        // Merge this config into existing config
-        // Ignoring keys we treated specially up above
-        this._config = merge(
-            omit(config, "dirs"),
-            this._config,
-            
-            // Disable lodash's default array merging behavior,
-            // see https://github.com/tivac/dullard/issues/15
-            function disableMerging(a, b) {
-                return Array.isArray(b) ? b : undefined;
-            }
-        );
-
-        this.steps = this._config.steps;
 
         // Supporting merging in other .dullfiles
+        // needs to happen before this config gets merged to preserve expected
+        // merging order
         if(config.includes) {
             if(file) {
                 cwd = path.dirname(file);
@@ -291,6 +278,21 @@ assign(Build.prototype, {
                 self.addConfig(path.resolve(cwd, include));
             });
         }
+        
+        // Merge this config into existing config
+        // Ignoring keys we treated specially up above
+        this._config = merge(
+            this._config,
+            omit(config, "dirs", "includes"),
+            
+            // Disable lodash's default array merging behavior,
+            // see https://github.com/tivac/dullard/issues/15
+            function disableMerging(a, b) {
+                return Array.isArray(b) ? b : undefined;
+            }
+        );
+
+        this.steps = this._config.steps;
     }
 });
 

--- a/test/cli.js
+++ b/test/cli.js
@@ -292,6 +292,34 @@ describe("Dullard", function() {
             assert.equal(result._config.nested.nested.argv, "argv");
         });
 
+        it("should let argv config values override everything else", function() {
+            var cli, result;
+
+            process.chdir("./test/specimens/config-include");
+            
+            cli = new Cli({
+                argv : [].concat(
+                    _argv,
+                    "--argv=argv",
+                    "--nested.config-js=argv"
+                ),
+                Dullard : Dullard
+            });
+
+            result = cli._dullard();
+
+            assert(result._config);
+            
+            assert.equal(result._config.argv, "argv");
+            assert.equal(result._config["config-js"], "config-js");
+            assert.equal(result._config["config-include"], "config-include");
+            
+            assert.deepEqual(result._config.nested, {
+                "config-js"      : "argv",
+                "config-include" : "config-include"
+            });
+        });
+
         it("should run steps passed in via argv", function() {
             var result = "",
                 cli;

--- a/test/dullard.addconfig.js
+++ b/test/dullard.addconfig.js
@@ -88,7 +88,7 @@ describe("Dullard", function() {
             d.addConfig(path.resolve(__dirname, "./specimens/config-deep/.dullfile"));
             d.addConfig(path.resolve(__dirname, "./specimens/config-deep/fooga/.dullfile"));
             d.addConfig(path.resolve(__dirname, "./specimens/config-deep/fooga/wooga/.dullfile"));
-
+            
             assert.equal(Object.keys(d.tasks).length, 6);
             assert("a-async" in d.tasks);
             assert("a" in d.tasks);
@@ -97,9 +97,9 @@ describe("Dullard", function() {
             assert("c-async" in d.tasks);
             assert("c" in d.tasks);
 
-            assert.equal(d._config.steps.default.length, 2);
-            assert.equal(d._config.steps.default[0], "a");
-            assert.equal(d._config.steps.default[1], "a-async");
+            assert.deepEqual(d._config.steps, {
+                default : [ "c", "c-async" ]
+            });
         });
 
         it("should mix multiple \"steps\" when they are objects", function() {
@@ -108,15 +108,11 @@ describe("Dullard", function() {
             d.addConfig(path.resolve(__dirname, "./specimens/config-objects/.dullfile"));
             d.addConfig(path.resolve(__dirname, "./specimens/config-objects/fooga/.dullfile"));
             
-            assert(Object.keys(d._config.steps).length);
-            assert.equal(d._config.steps["a-steps"].length, 1);
-            assert.equal(d._config.steps["a-steps"][0], "a");
-            
-            assert.equal(d._config.steps["b-steps"].length, 2);
-            assert.equal(d._config.steps["b-steps"][0], "b");
-            
-            assert.equal(d._config.steps["a-steps"].length, 1);
-            assert.equal(d._config.steps["c-steps"][0], "c");
+            assert.deepEqual(d._config.steps, {
+                "a-steps" : [ "a" ],
+                "b-steps" : [ "b-async" ],
+                "c-steps" : [ "c" ]
+            });
         });
 
         it("should load any additional configs defined in \"includes\"", function() {


### PR DESCRIPTION
Changes in `v1.1.1` made includes actually work, but also exposed some weird quirks in the merge ordering rules.

In general, it should always be furthest -> closer -> closest, with closest winning out and overriding any previous declarations. This wasn't always the case previously and that caused issues.

`includes` will be merged before the config that references them, but **after** any configs higher up in the directory structure.